### PR TITLE
Fix sound event bindings; Make (lack of) concurrency explicit

### DIFF
--- a/src/ffi/bindings/orx_bindings.re
+++ b/src/ffi/bindings/orx_bindings.re
@@ -458,12 +458,9 @@ module Bindings = (F: Ctypes.FOREIGN) => {
     let set_target_anim =
       c("orxObject_SetTargetAnim", t @-> string @-> returning(Status.t));
 
-    // NOTE: This is commented out and bound with Foreign/libffi
-    // The libffi binding is used because this function needs to
-    // release the OCaml runtime lock while running.
-    // // Sound
-    // let add_sound =
-    //   c("orxObject_AddSound", t @-> string @-> returning(Status.t));
+    // Sound
+    let add_sound =
+      c("orxObject_AddSound", t @-> string @-> returning(Status.t));
 
     // Linking structures
     let link_structure =
@@ -526,6 +523,8 @@ module Bindings = (F: Ctypes.FOREIGN) => {
       | Input: event(T.Input_event.t)
       | Physics: event(T.Physics_event.t)
       | Sound: event(T.Sound_event.t);
+
+    let get_flag = c("orxEVENT_GET_FLAG", uint32_t @-> returning(uint32_t));
 
     let to_event_id = (event: t): int64 => {
       Ctypes.getf(!@event, T.Event.event_id) |> Unsigned.UInt.to_int64;

--- a/src/ffi/stubgen/orx_stubgen.re
+++ b/src/ffi/stubgen/orx_stubgen.re
@@ -3,18 +3,27 @@ let prefix = "orx_stub";
 let prologue = {|
 #include <orx.h>
 
-orxSTATUS ml_orx_thread_pre() {
+orxSTATUS ml_orx_event_add_handler(orxEVENT_TYPE event_type, orxEVENT_HANDLER event_handler, orxU32 add_id_flags, orxU32 remove_id_flags) {
+  orxSTATUS result = orxSTATUS_SUCCESS;
+  result = orxEvent_AddHandler(event_type, event_handler);
+  if (result == orxSTATUS_SUCCESS) {
+    result = orxEvent_SetHandlerIDFlags(event_handler, event_type, NULL, add_id_flags, remove_id_flags);
+  }
+  return result;
+}
+
+orxSTATUS ml_orx_thread_start(void *_context) {
   caml_c_thread_register();
   return orxSTATUS_SUCCESS;
 }
 
-void ml_orx_thread_post() {
+void ml_orx_thread_stop(void *_context) {
   caml_c_thread_unregister();
   return orxSTATUS_SUCCESS;
 }
 
-void ml_orx_thread_set_prepost() {
-  orxThread_SetPrePost(&ml_orx_thread_pre, &ml_orx_thread_post, NULL);
+void ml_orx_thread_set_callbacks() {
+  orxThread_SetCallbacks(&ml_orx_thread_start, &ml_orx_thread_stop, NULL);
   return;
 }
 
@@ -43,11 +52,15 @@ let () = {
       "stubgen [-ml|-c]",
     )
   );
+
+  // OCaml/C concurrency model to use in the generated stubs
+  let concurrency = Cstubs.sequential;
   switch (generate_ml^, generate_c^) {
   | (false, false)
   | (true, true) => failwith("Exactly one of -ml, -c, -t must be specified")
   | (true, false) =>
     Cstubs.write_ml(
+      ~concurrency,
       Format.std_formatter,
       ~prefix,
       (module Orx_bindings.Bindings),
@@ -55,6 +68,7 @@ let () = {
   | (false, true) =>
     print_endline(prologue);
     Cstubs.write_c(
+      ~concurrency,
       Format.std_formatter,
       ~prefix,
       (module Orx_bindings.Bindings),

--- a/src/types/bindings/orx_types_bindings.re
+++ b/src/types/bindings/orx_types_bindings.re
@@ -448,34 +448,36 @@ module Bindings = (F: Ctypes.TYPE) => {
       | Start
       | Stop
       | Add
-      | Remove
-      | Packet
-      | Recording_start
-      | Recording_stop
-      | Recording_packet
-      | None;
+      | Remove;
+    /* TODO: If someone finds a way to safely handle these from OCaml, add
+       support back in.
+       | Packet
+       | Recording_start
+       | Recording_stop
+       | Recording_packet
+       | None; */
 
     let make = tag => F.constant("orxSOUND_EVENT_" ++ tag, F.int64_t);
     let start = make("START");
     let stop = make("STOP");
     let add = make("ADD");
     let remove = make("REMOVE");
-    let packet = make("PACKET");
-    let recording_start = make("RECORDING_START");
-    let recording_stop = make("RECORDING_STOP");
-    let recording_packet = make("RECORDING_PACKET");
-    let none = make("NONE");
+    /* let packet = make("PACKET");
+       let recording_start = make("RECORDING_START");
+       let recording_stop = make("RECORDING_STOP");
+       let recording_packet = make("RECORDING_PACKET");
+       let none = make("NONE"); */
 
     let map_to_constant = [
       (Start, start),
       (Stop, stop),
       (Add, add),
       (Remove, remove),
-      (Packet, packet),
-      (Recording_start, recording_start),
-      (Recording_stop, recording_stop),
-      (Recording_packet, recording_packet),
-      (None, none),
+      /* (Packet, packet),
+         (Recording_start, recording_start),
+         (Recording_stop, recording_stop),
+         (Recording_packet, recording_packet),
+         (None, none), */
     ];
 
     let map_from_constant = swap_tuple_list(map_to_constant);


### PR DESCRIPTION
Sound events are "fixed" by disallowing events which are potentially
triggered from a separate thread.  This avoids some significant
challenges and manually written binding code which would be required
to properly deal with OCaml runtime lock juggling.