### PR TITLE
Add Orx.Log module

### DIFF
--- a/src/ffi/bindings/orx_bindings.ml
+++ b/src/ffi/bindings/orx_bindings.ml
@@ -1195,4 +1195,14 @@ module Bindings (F : Ctypes.FOREIGN) = struct
 
     let get_key = c "orxLocale_GetKey" (uint32_t @-> returning string)
   end
+
+  module Log = struct
+    let log = c "orxLOG" (string @-> returning void)
+
+    let terminal = c "orxLOG_TERMINAL" (string @-> returning void)
+
+    let file = c "orxLOG_FILE" (string @-> returning void)
+
+    let console = c "orxLOG_CONSOLE" (string @-> returning void)
+  end
 end

--- a/src/ffi/orx.ml
+++ b/src/ffi/orx.ml
@@ -37,6 +37,16 @@ module Mouse_axis = Orx_types.Mouse_axis
 module Mouse_button = Orx_types.Mouse_button
 module Sound_status = Orx_types.Sound_status
 
+module Log = struct
+  type 'a format_logger =
+    ('a, Format.formatter, unit, unit, unit, unit) format6 -> 'a
+
+  let log fmt = Fmt.kstr Orx_gen.Log.log fmt
+  let terminal fmt = Fmt.kstr Orx_gen.Log.terminal fmt
+  let file fmt = Fmt.kstr Orx_gen.Log.file fmt
+  let console fmt = Fmt.kstr Orx_gen.Log.console fmt
+end
+
 module Viewport = struct
   include Orx_gen.Viewport
 

--- a/src/ffi/orx.mli
+++ b/src/ffi/orx.mli
@@ -23,6 +23,24 @@ module Status : sig
       checking. *)
 end
 
+module Log : sig
+  type 'a format_logger =
+    ('a, Format.formatter, unit, unit, unit, unit) format6 -> 'a
+  (** All formatting functions act as standard {!Stdlib.Format} formatters. *)
+
+  val log : 'a format_logger
+  (** Log with output going to all of Orx's log targets. *)
+
+  val terminal : 'a format_logger
+  (** Log with output going to the terminal. *)
+
+  val file : 'a format_logger
+  (** Log with output going to Orx's log file(s). *)
+
+  val console : 'a format_logger
+  (** Log with output going to the Orx console. *)
+end
+
 module Color : sig
   type t
 end


### PR DESCRIPTION
This can be merged once orx/orx#54 is merged or a similar fix is made for the `orxLOG_CONSOLE` macro.