### PR TITLE
Fix discover include path and other build issues on Windows

### DIFF
--- a/src/discover/discover.ml
+++ b/src/discover/discover.ml
@@ -57,13 +57,13 @@ let () =
       let platform = Platform.detect c in
       let orx_c_link_dir = orx_dir /+ "lib" /+ "dynamic" in
       let orx_c_library =
-        let extension =
+        let (prefix, extension) =
           match platform with
-          | Linux -> "so"
-          | Macos -> "dylib"
-          | Windows -> "dll"
+          | Linux -> ("lib", "so")
+          | Macos -> ("lib", "dylib")
+          | Windows -> ("", "dll")
         in
-        "liborxd." ^ extension
+        prefix ^ "orxd." ^ extension
       in
       let orx_c_library_location = orx_c_link_dir /+ orx_c_library in
       let orx_c_link_libs =

--- a/src/discover/discover.ml
+++ b/src/discover/discover.ml
@@ -29,8 +29,12 @@ module Platform = struct
       close_out fd;
       file
     in
+    let header_basename = Filename.basename header in
+    let header_path = Filename.dirname header in
+    let c_flags = [ "-I"; header_path ] in
+    let includes = [ header_basename ] in
     let platform =
-      C.C_define.import c ~includes:[ header ] [ ("PLATFORM_NAME", String) ]
+      C.C_define.import c ~c_flags ~includes [ ("PLATFORM_NAME", String) ]
     in
     match platform with
     | [ (_, String "linux") ] -> Linux

--- a/src/ffi/stubgen/orx_stubgen.ml
+++ b/src/ffi/stubgen/orx_stubgen.ml
@@ -25,10 +25,7 @@ ML_ORX_COMMAND_VAR_GET(orxFLOAT, float, fValue)
 ML_ORX_COMMAND_VAR_GET(orxBOOL, bool, bValue)
 ML_ORX_COMMAND_VAR_GET(orxU64, guid, u64Value)
 
-#define ML_ORX_COMMAND_VAR_SET(FIELD_TYPE, NAME, FIELD) \
-static orxINLINE void ml_orx_command_var_set_##NAME(orxCOMMAND_VAR *v, FIELD_TYPE vv) { \
-  v->FIELD = vv; \
-}
+#define ML_ORX_COMMAND_VAR_SET(FIELD_TYPE, NAME, FIELD) static orxINLINE void ml_orx_command_var_set_##NAME(orxCOMMAND_VAR *v, FIELD_TYPE vv) { v->FIELD = vv; }
 ML_ORX_COMMAND_VAR_SET(orxVECTOR, vector, vValue)
 ML_ORX_COMMAND_VAR_SET(orxSTRING, string, zValue)
 ML_ORX_COMMAND_VAR_SET(orxS64, int, s64Value)

--- a/src/ffi/stubgen/orx_stubgen.ml
+++ b/src/ffi/stubgen/orx_stubgen.ml
@@ -44,32 +44,9 @@ static orxINLINE void ml_orx_shader_param_set_vector(orxSHADER_EVENT_PAYLOAD *pa
   orxASSERT(payload->eParamType == orxSHADER_PARAM_TYPE_VECTOR);
   orxVector_Copy(&(payload->vValue), v);
 }
-
-/* Event handlers */
-
-orxSTATUS ml_orx_event_add_handler(orxEVENT_TYPE event_type, orxEVENT_HANDLER event_handler, orxU32 add_id_flags, orxU32 remove_id_flags) {
-  orxSTATUS result = orxSTATUS_SUCCESS;
-  result = orxEvent_AddHandler(event_type, event_handler);
-  if (result == orxSTATUS_SUCCESS) {
-    result = orxEvent_SetHandlerIDFlags(event_handler, event_type, NULL, add_id_flags, remove_id_flags);
-  }
-  return result;
-}
-
-/* Main engine entrypoint */
-
-void ml_orx_execute(int argc, char **argv,
-                    orxMODULE_INIT_FUNCTION init,
-                    orxMODULE_RUN_FUNCTION run,
-                    orxMODULE_EXIT_FUNCTION exit) {
-    orx_Execute(argc,
-                argv,
-                init,
-                run,
-                exit);
-    return;
-}
 |}
+
+let prologue = String.split_on_char '\n' prologue |> List.map String.trim
 
 let () =
   let (generate_ml, generate_c) = (ref false, ref false) in
@@ -89,5 +66,5 @@ let () =
   | (true, false) ->
     Cstubs.write_ml Format.std_formatter ~prefix (module Orx_bindings.Bindings)
   | (false, true) ->
-    print_endline prologue;
+    List.iter print_endline prologue;
     Cstubs.write_c Format.std_formatter ~prefix (module Orx_bindings.Bindings)

--- a/src/lib/orx_manual_stubs.c
+++ b/src/lib/orx_manual_stubs.c
@@ -28,3 +28,31 @@ value ml_orx_thread_set_callbacks(value _unit)
     orxThread_SetCallbacks(&ml_orx_thread_start, &ml_orx_thread_stop, NULL);
     CAMLreturn(Val_unit);
 }
+
+/* Event handlers */
+
+orxSTATUS ml_orx_event_add_handler(orxEVENT_TYPE event_type, orxEVENT_HANDLER event_handler, orxU32 add_id_flags, orxU32 remove_id_flags)
+{
+    orxSTATUS result = orxSTATUS_SUCCESS;
+    result = orxEvent_AddHandler(event_type, event_handler);
+    if (result == orxSTATUS_SUCCESS)
+    {
+        result = orxEvent_SetHandlerIDFlags(event_handler, event_type, NULL, add_id_flags, remove_id_flags);
+    }
+    return result;
+}
+
+/* Main engine entrypoint */
+
+void ml_orx_execute(int argc, char **argv,
+                    orxMODULE_INIT_FUNCTION init,
+                    orxMODULE_RUN_FUNCTION run,
+                    orxMODULE_EXIT_FUNCTION exit)
+{
+    orx_Execute(argc,
+                argv,
+                init,
+                run,
+                exit);
+    return;
+}


### PR DESCRIPTION
This makes some fixes to the Windows build since it hadn't received much attention recently.

- Specifying the include path on the command line keeps escaping simpler and fixes some `#include` handling
- Make sure line endings are correct on Windows and Unix-y OSs
- Windows orx shared library doesn't have a `lib` prefix

The Windows build issues were highlighted in the initial addition of github actions in #13 