### PR TITLE
Use any orx build variant

### DIFF
--- a/src/ffi/stubgen/dune
+++ b/src/ffi/stubgen/dune
@@ -21,6 +21,6 @@
    (run
     install_name_tool
     -change
-    @executable_path/liborxd.dylib
+    @executable_path/%{read-lines:../../discover/orx-c-library.txt}
     %{read-lines:../../discover/orx-c-library-location.txt}
     %{targets}))))

--- a/src/types/stubgen/dune
+++ b/src/types/stubgen/dune
@@ -51,6 +51,6 @@
    (run
     install_name_tool
     -change
-    @executable_path/liborxd.dylib
+    @executable_path/%{read-lines:../../discover/orx-c-library.txt}
     %{read-lines:../../discover/orx-c-library-location.txt}
     %{targets}))))


### PR DESCRIPTION
This updates the `dune` discover code to pick an orx library build based on what's available rather than only supporting the the `orxd` debug build. It will pick the first available from debug, profile or release builds.

There is also a bit of general code cleanup in `discover.ml`.